### PR TITLE
chore(ci): don't persist checkout's GITHUB_TOKEN credentials

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,4 +1,4 @@
-name: Build and deploy releases & rcs
+name: Build, release and deploy releases & rcs
 on:
   push:
     branches:
@@ -6,13 +6,17 @@ on:
       - next
 jobs:
   release:
-    name: Release
+    name: Build, release and deploy
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          # Don't persist credentials or semantic-release will use them
+          # and fail with protected branches. For discussion and other
+          # possible solutions, see: https://github.com/semantic-release/git/issues/196.
+          persist-credentials: false
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
They're not enough to push tags to protected branches and semantic
release will fail if GITHUB_TOKEN is used. Now it should use separate
secrets.GH_TOKEN which has rights to push tags to protected branch.
(Tested with "anonymous clone using https" + command:
`git push --tags https://${GH_TOKEN}@github.com/symcode-fi/vue-tools-test.git`)