### PR TITLE
fix: test prev ver assets with patch .9

### DIFF
--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -17,7 +17,7 @@ h3
 .feat
   small {{ t('small-feat') }}
 .feat {{ t('cache-control-test-feat') }}
-.fix.text-secondary {{ t('test-fix', {n: "real .2"}) }}
+.fix.text-secondary {{ t('test-fix', {n: ".9 after skipped ones"}) }}
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
Skipped few patch versions by manually pushing .8 tag.